### PR TITLE
Add IRENA datasets for Renewable Capacity & Generation

### DIFF
--- a/ene_XXX_renewable_generation_annually/Makefile
+++ b/ene_XXX_renewable_generation_annually/Makefile
@@ -1,0 +1,16 @@
+.PHONY: default
+default: generation capacity
+
+.PHONY: capacity
+capacity:
+	python ene_XXX_renewable_capacity_annually.py
+
+.PHONY: generation
+generation:
+	python ene_XXX_renewable_generation_annually.py
+
+.PHONY: clean
+clean:
+	rm *.zip
+	rm ene_XXX_renewable_capacity_annually_edit.csv
+	rm ene_XXX_renewable_generation_annually_edit.csv

--- a/ene_XXX_renewable_generation_annually/README.md
+++ b/ene_XXX_renewable_generation_annually/README.md
@@ -1,0 +1,72 @@
+## {Resource Watch Public Title} Dataset Pre-processing
+This file describes the data pre-processing that was done to [IRENA Renewable Energy Capacity](https://irena.org/publications/2020/Mar/Renewable-Capacity-Statistics-2020) and [IRENA Renewable Energy Generation]() to prepare for their upload to Resource Watch.
+
+IRENA annually releases [a publication](https://irena.org/publications/2020/Mar/Renewable-Capacity-Statistics-2020) on capacity and renewable energy generation by nation, year, and technology.
+This information is readily accessed through their [Data and Statistics page](https://irena.org/Statistics/View-Data-by-Topic/Capacity-and-Generation/Statistics-Time-Series), and can be downloaded from a Tableau dashboard.
+As an example this dataset has granularity for capacity (units of MW) or generation (units of GWh) that looks like `{2015, Cambodia, Onshore Wind, On-grid}`.
+
+This directory holds scripts to produce **two** datasets for upload.
+
+### Data License
+The publication [IRENA Renewable Energy Capacity](https://irena.org/publications/2020/Mar/Renewable-Capacity-Statistics-2020) states:
+
+```
+Copyright (c) IRENA 2020
+Unless otherwise stated, material in this publication may be freely used, shared, copied,
+reproduced, printed and/or stored, provided that appropriate acknowledgement is given of
+IRENA as the source and copyright holder.
+Material in this publication that is attributed to third parties may be subject
+to separate terms of use and restrictions, and appropriate permissions from
+these third parties may need to be secured before any use of such material.
+```
+
+The Tableau download does not clearly denote its license availability.
+
+
+### Data Acquisition
+1. Point web browser to:
+   [https://public.tableau.com/views/IRENARETimeSeries/Charts?%3Aembed=y&%3AshowVizHome=no&publish=yes&%3Atoolbar=no](https://public.tableau.com/views/IRENARETimeSeries/Charts?%3Aembed=y&%3AshowVizHome=no&publish=yes&%3Atoolbar=no)
+
+2. Ensure right-side dimensions are set to:
+   ```
+   "level_of_detail": "cumulative",
+   "flow": "Electricity Generation",
+   "grid_connection": "(all)",
+   "region": "(all)",
+   "country/area": "(all)",
+   "technology": "(all)",
+   "sub-technology": "(all)",
+   "year": "(all)"
+   ```
+
+3. Click the excel icon in the top-right.
+   This file can be discarded - it is not needed.
+   This step is necessary to activate the button for step 5.
+
+4. Click the download icon in the bottom right, within the Tableau footer
+
+5. Select 'data' from the format options
+
+6. Switch to the 'Full Data' tab
+
+7. Select the 'Show all columns' checkbox
+
+8. Click "Download all rows as a text file"
+
+9. Copy the downloaded file into this python script's parent directory
+
+10. Name the file the value of `LOCAL_INPUT_FILE` in the script, or the converse
+
+
+### Data Processing
+Please see the [Python scripts]() for more details on this processing.
+A quick overview is that the data is aggregated based on year, country, sub-technology (e.g. onshore wind, solar thermal, etc), and on-grid/off-grid.
+The initial input file contains both generation and capacity rows, so those are subset early on.
+
+This processing follows the original choice by IRENA to default to filtering out Pumped Storage hydro plants.
+These plants are downloaded in the original file to be complete, but are not present in the transformed data.
+
+
+You can view the processed dataset [on Resource Watch]().
+
+###### Note: This dataset processing was done by [Logan Byers](https://www.wri.org/profile/logan-byers), and QC'd by [{name}]({link to WRI bio page}).

--- a/ene_XXX_renewable_generation_annually/ene_XXX_renewable_capacity_annually.py
+++ b/ene_XXX_renewable_generation_annually/ene_XXX_renewable_capacity_annually.py
@@ -1,0 +1,150 @@
+"""Script to transform and upload IRENA's capacity data to Resource Watch.
+
+IRENA information is available through a Tableau applet.
+This data must be downloaded manually, it is not possible to acquire
+through an HTTP GET as we can tell.
+
+Once downloaded, only minor transformation is needed to prepare it for upload.
+The core issue is that the information does not fall into a data cube without
+aggregating some rows to fit with expectations around data dimensionality.
+
+It seems the data should be keyed on the dimensions:
+    - country
+    - year
+    - most granular technology (e.g. "offshore wind" not "wind")
+    - on-grid/off-grid
+
+When keyed in this way there are still many compound keys
+that have multiple rows and need to be summed to produce the
+values expressed in Tableau visualization.
+
+"""
+# set True to prevent uploading to S3 & Carto
+# set False to do the upload - requires API keys in ENV
+DRY_RUN = True
+
+import os
+import pandas as pd
+from zipfile import ZipFile
+import shutil
+
+if not DRY_RUN:
+    from carto.datasets import DatasetManager
+    from carto.auth import APIKeyAuthClient
+    import boto3
+    from botocore.exceptions import NoCredentialsError
+
+
+# name of table on Carto where you want to upload data
+# this should be a table name that is not currently in use
+CARTO_TABLE_NAME = 'ene_XXX_renewable_capacity_annually'
+
+# see this processing workflow README for info on the input file
+LOCAL_INPUT_FILE = 'IRENA-full-data-table-2020.csv'
+LOCAL_ZIPFILE_FOR_INPUT = '{0}.zip'.format(CARTO_TABLE_NAME)
+LOCAL_OUTPUT_FILE = '{0}_edit.csv'.format(CARTO_TABLE_NAME)
+LOCAL_ZIPFILE_FOR_OUTPUT = '{0}_edit.zip'.format(CARTO_TABLE_NAME)
+
+# ensure required file is present
+assert LOCAL_INPUT_FILE in os.listdir(os.curdir)
+
+
+# read in csv file as Dataframe
+df = pd.read_csv(LOCAL_INPUT_FILE, dtype=str)
+
+# filter pumped storage plants just like IRENA default
+df = df[df['Sub-technology'] != 'Pumped Storage']
+
+# convert values from string to float because summing later
+df['Values_asfloat'] = df['Values'].astype(float)
+
+# subset into capacity
+capacity_data = df[df['DataType'] == 'Installed Capacity']
+
+# assuming MW everywhere, check that; yes the field name has a space at the end
+assert (capacity_data['Unit '] == 'MW').all()
+
+# group by the key dimensions
+grouped =  capacity_data.groupby(['ISO', 'Years', 'Sub-technology', 'Type'])
+# ensure Technology is mapped 1:1 with Sub-technology
+assert grouped.agg({'Technology': lambda x: len(set(x)) == 1}).Technology.all()
+
+# create the data frame, renaming values and organizing the column order
+data = grouped.agg({
+        'Values_asfloat': 'sum',  # sum the numeric capacity value
+        'IRENA Label': 'first',  # take a long name for the country
+        'Technology': 'first',  # take the technology (superclass) 
+    }).reset_index().rename(columns={
+        'ISO': 'iso_a3',
+        'Years': 'year',
+        'Sub-technology': 'subtechnology',
+        'Technology': 'technology',
+        'Type': 'grid_connection',
+        'IRENA Label': 'country_name',
+        'Values_asfloat': 'capacity_MW',
+    })[[  # set a new column order
+        'iso_a3',  # key
+        'country_name',  # 1:1 with iso_a3
+        'year', # key
+        'subtechnology',  # key
+        'technology',  # 1:n with subtechnology
+        'grid_connection',  # key
+        'capacity_MW'  # the numeric value in megawatts
+    ]]
+
+
+# save processed dataset to csv
+data.to_csv(LOCAL_OUTPUT_FILE, index=False)
+
+
+if not DRY_RUN:
+    # Upload processed data to Carto
+    print('Uploading processed data to Carto.')
+    #set up carto authentication using local variables for username (CARTO_WRI_RW_USER) and API key (CARTO_WRI_RW_KEY)
+    auth_client = APIKeyAuthClient(api_key=os.getenv('CARTO_WRI_RW_KEY'), base_url="https://{user}.carto.com/".format(user=os.getenv('CARTO_WRI_RW_USER')))
+    #set up dataset manager with authentication
+    dataset_manager = DatasetManager(auth_client)
+    #upload dataset to carto
+    dataset = dataset_manager.create(LOCAL_OUTPUT_FILE)
+    print('Carto table created: {}'.format(LOCAL_OUTPUT_FILE))
+    #set dataset privacy to 'Public with link'
+    dataset.privacy = 'LINK'
+    dataset.save()
+    print('Privacy set to public with link.')
+
+
+# Copy the raw data into a zipped file to upload to S3
+with ZipFile(LOCAL_ZIPFILE_FOR_INPUT, 'w') as z:
+    z.write(LOCAL_OUTPUT_FILE, '{0}.csv'.format(CARTO_TABLE_NAME))
+
+# Copy the processed data into a zipped file to upload to S3
+with ZipFile(LOCAL_ZIPFILE_FOR_OUTPUT, 'w') as z:
+    z.write(LOCAL_OUTPUT_FILE, LOCAL_OUTPUT_FILE)
+
+if not DRY_RUN:
+    '''
+    Upload original data and processed data to Amazon S3 storage
+    '''
+    def upload_to_aws(local_file, bucket, s3_file):
+        s3 = boto3.client('s3', aws_access_key_id=os.getenv('aws_access_key_id'), aws_secret_access_key=os.getenv('aws_secret_access_key'))
+        try:
+            s3.upload_file(local_file, bucket, s3_file)
+            print("Upload Successful")
+            print("http://{}.s3.amazonaws.com/{}".format(bucket, s3_file))
+            return True
+        except FileNotFoundError:
+            print("The file was not found")
+            return False
+        except NoCredentialsError:
+            print("Credentials not available")
+            return False
+
+    # Upload raw data file to S3
+    print('Uploading original data to S3.')
+    uploaded_input = upload_to_aws(LOCAL_ZIPFILE_FOR_INPUT, 'wri-public-data',
+            'resourcewatch/' + LOCAL_ZIPFILE_FOR_INPUT)
+
+    print('Uploading processed data to S3.')
+    # Upload processed data file to S3
+    uploaded_output = upload_to_aws(LOCAL_ZIPFILE_FOR_OUTPUT, 'wri-public-data',
+        'resourcewatch/' + LOCAL_ZIPFILE_FOR_OUTPUT)

--- a/ene_XXX_renewable_generation_annually/ene_XXX_renewable_generation_annually.py
+++ b/ene_XXX_renewable_generation_annually/ene_XXX_renewable_generation_annually.py
@@ -1,0 +1,153 @@
+"""Script to transform and upload IRENA's capacity data to Resource Watch.
+
+IRENA information is available through a Tableau applet.
+This data must be downloaded manually, it is not possible to acquire
+through an HTTP GET as we can tell.
+
+Once downloaded, only minor transformation is needed to prepare it for upload.
+The core issue is that the information does not fall into a data cube without
+aggregating some rows to fit with expectations around data dimensionality.
+
+It seems the data should be keyed on the dimensions:
+    - country
+    - year
+    - most granular technology (e.g. "offshore wind" not "wind")
+    - on-grid/off-grid
+
+When keyed in this way there are still many compound keys
+that have multiple rows and need to be summed to produce the
+values expressed in Tableau visualization.
+
+"""
+# set True to prevent uploading to S3 & Carto
+# set False to do the upload - requires API keys in ENV
+DRY_RUN = True
+
+import os
+import pandas as pd
+from zipfile import ZipFile
+import shutil
+
+if not DRY_RUN:
+    from carto.datasets import DatasetManager
+    from carto.auth import APIKeyAuthClient
+    import boto3
+    from botocore.exceptions import NoCredentialsError
+
+
+# name of table on Carto where you want to upload data
+# this should be a table name that is not currently in use
+CARTO_TABLE_NAME = 'ene_XXX_renewable_generation_annually'
+
+# see this processing workflow README for info on the input file
+LOCAL_INPUT_FILE = 'IRENA-full-data-table-2020.csv'
+LOCAL_ZIPFILE_FOR_INPUT = '{0}.zip'.format(CARTO_TABLE_NAME)
+LOCAL_OUTPUT_FILE = '{0}_edit.csv'.format(CARTO_TABLE_NAME)
+LOCAL_ZIPFILE_FOR_OUTPUT = '{0}_edit.zip'.format(CARTO_TABLE_NAME)
+
+# ensure required file is present
+assert LOCAL_INPUT_FILE in os.listdir(os.curdir)
+
+
+# read in csv file as Dataframe
+df = pd.read_csv(LOCAL_INPUT_FILE, dtype=str)
+
+# filter pumped storage plants just like IRENA default
+df = df[df['Sub-technology'] != 'Pumped Storage']
+
+# convert values from string to float because summing later
+df['Values_asfloat'] = df['Values'].astype(float)
+
+# subset into generation
+generation_data = df[df['DataType'] == 'Electricity Generation']
+
+# assuming GWh everywhere, check that; yes the field name has a space at the end
+assert (generation_data['Unit '] == 'GWh').all()
+
+# group by the key dimensions
+grouped =  generation_data.groupby(['ISO', 'Years', 'Sub-technology', 'Type'])
+# ensure Technology is mapped 1:1 with Sub-technology
+assert grouped.agg({'Technology': lambda x: len(set(x)) == 1}).Technology.all()
+
+# create the data frame, renaming values and organizing the column order
+data = grouped.agg({
+        'Values_asfloat': 'sum',  # sum the numeric capacity value
+        'IRENA Label': 'first',  # take a long name for the country
+        'Technology': 'first',  # take the technology (superclass) 
+    }).reset_index().rename(columns={
+        'ISO': 'iso_a3',
+        'Years': 'year',
+        'Sub-technology': 'subtechnology',
+        'Technology': 'technology',
+        'Type': 'grid_connection',
+        'IRENA Label': 'country_name',
+        'Values_asfloat': 'generation_GWh',
+    })[[  # set a new column order
+        'iso_a3',  # key
+        'country_name',  # 1:1 with iso_a3
+        'year', # key
+        'subtechnology',  # key
+        'technology',  # 1:n with subtechnology
+        'grid_connection',  # key
+        'generation_GWh'  # the numeric generation value in gigawatt-hours
+    ]]
+
+
+# save processed dataset to csv
+data.to_csv(LOCAL_OUTPUT_FILE, index=False)
+
+
+if not DRY_RUN:
+    # Upload processed data to Carto
+    print('Uploading processed data to Carto.')
+    #set up carto authentication using local variables for username (CARTO_WRI_RW_USER) and API key (CARTO_WRI_RW_KEY)
+    auth_client = APIKeyAuthClient(
+			api_key=os.getenv('CARTO_WRI_RW_KEY'),
+			base_url="https://{user}.carto.com/".format(user=os.getenv('CARTO_WRI_RW_USER'))
+			)
+    #set up dataset manager with authentication
+    dataset_manager = DatasetManager(auth_client)  # this is an unofficial API feature?
+    #upload dataset to carto
+    dataset = dataset_manager.create(LOCAL_OUTPUT_FILE)
+    print('Carto table created: {}'.format(LOCAL_OUTPUT_FILE))
+    #set dataset privacy to 'Public with link'
+    dataset.privacy = 'LINK'
+    dataset.save()
+    print('Privacy set to public with link.')
+
+
+# Copy the raw data into a zipped file to upload to S3
+with ZipFile(LOCAL_ZIPFILE_FOR_INPUT, 'w') as z:
+    z.write(LOCAL_OUTPUT_FILE, '{0}.csv'.format(CARTO_TABLE_NAME))
+
+# Copy the processed data into a zipped file to upload to S3
+with ZipFile(LOCAL_ZIPFILE_FOR_OUTPUT, 'w') as z:
+    z.write(LOCAL_OUTPUT_FILE, LOCAL_OUTPUT_FILE)
+
+if not DRY_RUN:
+    '''
+    Upload original data and processed data to Amazon S3 storage
+    '''
+    def upload_to_aws(local_file, bucket, s3_file):
+        s3 = boto3.client('s3', aws_access_key_id=os.getenv('aws_access_key_id'), aws_secret_access_key=os.getenv('aws_secret_access_key'))
+        try:
+            s3.upload_file(local_file, bucket, s3_file)
+            print("Upload Successful")
+            print("http://{}.s3.amazonaws.com/{}".format(bucket, s3_file))
+            return True
+        except FileNotFoundError:
+            print("The file was not found")
+            return False
+        except NoCredentialsError:
+            print("Credentials not available")
+            return False
+
+    # Upload raw data file to S3
+    print('Uploading original data to S3.')
+    uploaded_input = upload_to_aws(LOCAL_ZIPFILE_FOR_INPUT, 'wri-public-data',
+            'resourcewatch/' + LOCAL_ZIPFILE_FOR_INPUT)
+
+    print('Uploading processed data to S3.')
+    # Upload processed data file to S3
+    uploaded_output = upload_to_aws(LOCAL_ZIPFILE_FOR_OUTPUT, 'wri-public-data',
+        'resourcewatch/' + LOCAL_ZIPFILE_FOR_OUTPUT)

--- a/ene_XXX_renewable_generation_annually/requirements.txt
+++ b/ene_XXX_renewable_generation_annually/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+carto
+boto3


### PR DESCRIPTION
These datasets are not yet in Resource Watch, so the directory is viewed
as temporary for now.

I am not exactly sure how strict things are on "one upload, one directory".

I don't have API keys, so I added a program execution switch `DRY_RUN` which will avoid the cloud-uploading but still make the local files.


The goal here is to make two datasets - one for capacity (MW) and one for generation (GWh).
These datasets are both keyed by `{year, country, sub-technology, on/off-grid}`.

Happy to help with any changes, etc.