### PR TITLE
Initial ocean pull

### DIFF
--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
@@ -61,6 +61,9 @@ with ZipFile(raw_data_file, 'r') as zip:
         raise Exception()
     tifname = tifnames[0]
     zip.extractall(data_dir)
+'''
+Process data
+'''
 # in this case "processed" data file is just unzipped tif
 # but we have to rename it
 unprocessed_data_file = (os.path.join(data_dir,tifname))

--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# ## Preparation
+
+# #### Import
+
+# In[1]:
+
+
+import os
+import sys
+import dotenv
+dotenv.load_dotenv(os.path.abspath(os.getenv('RW_ENV')))
+
+
+# In[2]:
+
+
+if os.getenv('PROCESSING_DIR') not in sys.path:
+    sys.path.append(os.path.abspath(os.getenv('PROCESSING_DIR')))
+import util_files
+import util_cloud
+
+
+# In[3]:
+
+
+# import boto3
+# from botocore.exceptions import NoCredentialsError
+import urllib
+from zipfile import ZipFile
+import ee
+import subprocess
+from google.cloud import storage
+from shutil import copyfile
+import time
+
+
+# #### Set/initialize/authenticate general variables
+
+# In[4]:
+
+
+# set up Google Cloud Storage project and bucket objects
+gcs_client = storage.Client(os.environ.get("CLOUDSDK_CORE_PROJECT"))
+gcs_bucket = gcs_client.bucket(os.environ.get("GEE_STAGING_BUCKET"))
+
+# initialize ee and eeUtil modules for uploading to Google Earth Engine
+auth = ee.ServiceAccountCredentials(os.getenv('GEE_SERVICE_ACCOUNT'), os.getenv('GOOGLE_APPLICATION_CREDENTIALS'))
+ee.Initialize(auth)
+
+aws_bucket = 'wri-projects'
+s3_prefix = 'resourcewatch/raster/'
+
+
+# #### Set dataset-specific variables
+
+# In[5]:
+
+
+# name of asset on GEE where you want to upload data
+# this should be an asset name that is not currently in use
+dataset_name = 'ocn_005_historical_cyclone_intensity'
+
+band_ids = ['cy_intensity', 
+           ]
+
+# set pyramiding policy for GEE upload
+pyramiding_policy = 'MEAN' #check
+
+
+# ## Execution
+
+# In[6]:
+
+
+data_dir = util_files.prep_dirs(dataset_name)
+
+
+# In[7]:
+
+
+'''
+Raw data must be downloaded manually and placed in appropriate folder
+'''
+# data source page:
+#     https://preview.grid.unep.ch/index.php?preview=data&events=cyclones&evcat=4&lang=eng
+# access dataset via "DOWNLOAD" option in sidebar, which prompts javascript popup
+# download data as GeoTiff
+# place resulting zip file in data folder
+# expected file name as of june 2020: 
+#     cy_intensity_20200408183708_tiff.zip
+
+raw_data_file = os.path.join(data_dir,'cy_intensity_20200408183708_tiff.zip')
+print(os.path.abspath(raw_data_file))
+
+
+# In[8]:
+
+
+print('Unzip raw data')
+with ZipFile(raw_data_file, 'r') as zip:
+    namelist = zip.namelist()
+    tifnames = [name for name in namelist if '.tif' in name]
+    if len(tifnames) != 1:
+        raise Exception()
+    tifname = tifnames[0]
+    zip.extractall(data_dir)
+# in this case "processed" data file is just unzipped tif
+# but we have to rename it
+unprocessed_data_file = (os.path.join(data_dir,tifname))
+processed_data_file = os.path.join(data_dir,dataset_name+'.tif')
+print (processed_data_file)
+copyfile(unprocessed_data_file, processed_data_file)
+
+
+# In[9]:
+
+
+print('Uploading processed data to Google Cloud Storage.')
+gcs_uris = util_cloud.gcs_upload(processed_data_file, dataset_name, gcs_bucket=gcs_bucket)
+
+
+# In[10]:
+
+
+import imp
+imp.reload(util_cloud)
+
+print('Uploading processed data to Google Earth Engine.')
+# name bands according to variable names in original netcdf
+bands = [{'id': band_id, 'tileset_band_index': band_ids.index(band_id), 'tileset_id': dataset_name, 'pyramidingPolicy': pyramiding_policy} for band_id in band_ids]
+
+# Upload processed data file to GEE
+asset_name = f'projects/resource-watch-gee/{dataset_name}'
+
+task_id = util_cloud.gee_ingest(gcs_uris[0], asset=asset_name, bands=bands, public=True)
+
+
+# In[11]:
+
+
+util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcs_bucket)
+print('Files deleted from Google Cloud Storage.')
+
+
+# In[12]:
+
+
+print('Uploading original data to S3.')
+# Upload raw data file to S3
+uploaded = util_cloud.aws_upload(raw_data_file, aws_bucket, s3_prefix+os.path.basename(raw_data_file))
+
+print('Uploading processed data to S3.')
+# Copy the processed data into a zipped file to upload to S3
+processed_data_dir = os.path.join(data_dir, dataset_name+'_edit.zip')
+with ZipFile(processed_data_dir,'w') as zip:
+    zip.write(processed_data_file, os.path.basename(processed_data_file))
+# Upload processed data file to S3
+uploaded = util_cloud.aws_upload(processed_data_dir, aws_bucket, s3_prefix+os.path.basename(processed_data_dir))
+

--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
@@ -1,4 +1,5 @@
-# ## Preparation
+# Author: Peter Kerins  
+# Date: 2020 Jun 23  
 
 # #### Import
 

--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
@@ -21,20 +21,6 @@ from google.cloud import storage
 from shutil import copyfile
 import time
 
-
-# #### Set/initialize/authenticate general variables
-
-# set up Google Cloud Storage project and bucket objects
-gcs_client = storage.Client(os.environ.get("CLOUDSDK_CORE_PROJECT"))
-gcs_bucket = gcs_client.bucket(os.environ.get("GEE_STAGING_BUCKET"))
-
-# initialize ee and eeUtil modules for uploading to Google Earth Engine
-auth = ee.ServiceAccountCredentials(os.getenv('GEE_SERVICE_ACCOUNT'), os.getenv('GOOGLE_APPLICATION_CREDENTIALS'))
-ee.Initialize(auth)
-
-aws_bucket = 'wri-projects'
-s3_prefix = 'resourcewatch/raster/'
-
 # #### Set dataset-specific variables
 
 # name of asset on GEE where you want to upload data

--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
@@ -91,7 +91,7 @@ asset_name = f'projects/resource-watch-gee/{dataset_name}'
 manifest = util_cloud.gee_manifest_complete(asset_name, gcs_uris[0], mf_bands)
 task_id = util_cloud.gee_ingest(manifest, public=True)
 
-util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcs_bucket)
+util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcsBucket)
 print('Files deleted from Google Cloud Storage.')
 
 '''

--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
@@ -66,6 +66,10 @@ processed_data_file = os.path.join(data_dir,dataset_name+'.tif')
 print (processed_data_file)
 copyfile(unprocessed_data_file, processed_data_file)
 
+'''
+Upload processed data to Google Earth Engine
+'''
+
 print('Uploading processed data to Google Cloud Storage.')
 # set up Google Cloud Storage project and bucket objects
 gcsClient = storage.Client(os.environ.get("CLOUDSDK_CORE_PROJECT"))

--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
@@ -83,7 +83,16 @@ gcsBucket = gcsClient.bucket(os.environ.get("GEE_STAGING_BUCKET"))
 gcs_uris = util_cloud.gcs_upload(processed_data_file, dataset_name, gcs_bucket=gcsBucket )
 
 print('Uploading processed data to Google Earth Engine.')
+# initialize ee and eeUtil modules for uploading to Google Earth Engine
+auth = ee.ServiceAccountCredentials(os.getenv('GEE_SERVICE_ACCOUNT'), os.getenv('GOOGLE_APPLICATION_CREDENTIALS'))
+ee.Initialize(auth)
+
+# set pyramiding policy for GEE upload
+pyramiding_policy = 'MEAN' #check
+           
 # name bands according to variable names in original netcdf
+band_ids = ['cy_intensity', 
+           ]
 mf_bands = [{'id': band_id, 'tileset_band_index': band_ids.index(band_id), 'tileset_id': dataset_name, 'pyramidingPolicy': pyramiding_policy} for band_id in band_ids]
 
 # Upload processed data file to GEE

--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
@@ -67,7 +67,11 @@ print (processed_data_file)
 copyfile(unprocessed_data_file, processed_data_file)
 
 print('Uploading processed data to Google Cloud Storage.')
-gcs_uris = util_cloud.gcs_upload(processed_data_file, dataset_name, gcs_bucket=gcs_bucket)
+# set up Google Cloud Storage project and bucket objects
+gcsClient = storage.Client(os.environ.get("CLOUDSDK_CORE_PROJECT"))
+gcsBucket = gcsClient.bucket(os.environ.get("GEE_STAGING_BUCKET"))
+
+gcs_uris = util_cloud.gcs_upload(processed_data_file, dataset_name, gcs_bucket=gcsBucket )
 
 print('Uploading processed data to Google Earth Engine.')
 # name bands according to variable names in original netcdf

--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
@@ -27,15 +27,8 @@ import time
 # this should be an asset name that is not currently in use
 dataset_name = 'ocn_005_historical_cyclone_intensity'
 
-band_ids = ['cy_intensity', 
-           ]
-
-# set pyramiding policy for GEE upload
-pyramiding_policy = 'MEAN' #check
-
-
-# ## Execution
-
+# create a new sub-directory within your specified dir called 'data'
+# within this directory, create files to store raw and processed data
 data_dir = util_files.prep_dirs(dataset_name)
 
 '''

--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
@@ -38,7 +38,9 @@ pyramiding_policy = 'MEAN' #check
 
 data_dir = util_files.prep_dirs(dataset_name)
 
-# acquire raw data
+'''
+Download data and save to your data directory
+'''
 
 # data source page:
 #     https://preview.grid.unep.ch/index.php?preview=data&events=cyclones&evcat=4&lang=eng

--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
@@ -84,12 +84,12 @@ gcs_uris = util_cloud.gcs_upload(processed_data_file, dataset_name, gcs_bucket=g
 
 print('Uploading processed data to Google Earth Engine.')
 # name bands according to variable names in original netcdf
-bands = [{'id': band_id, 'tileset_band_index': band_ids.index(band_id), 'tileset_id': dataset_name, 'pyramidingPolicy': pyramiding_policy} for band_id in band_ids]
+mf_bands = [{'id': band_id, 'tileset_band_index': band_ids.index(band_id), 'tileset_id': dataset_name, 'pyramidingPolicy': pyramiding_policy} for band_id in band_ids]
 
 # Upload processed data file to GEE
 asset_name = f'projects/resource-watch-gee/{dataset_name}'
-
-task_id = util_cloud.gee_ingest(gcs_uris[0], asset=asset_name, bands=bands, public=True)
+manifest = util_cloud.gee_manifest_complete(asset_name, gcs_uris[0], mf_bands)
+task_id = util_cloud.gee_ingest(manifest, public=True)
 
 util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcs_bucket)
 print('Files deleted from Google Cloud Storage.')

--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity.py
@@ -81,6 +81,13 @@ task_id = util_cloud.gee_ingest(manifest, public=True)
 util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcs_bucket)
 print('Files deleted from Google Cloud Storage.')
 
+'''
+Upload original data and processed data to Amazon S3 storage
+'''
+
+# initialize AWS variables
+aws_bucket = 'wri-projects'
+s3_prefix = 'resourcewatch/raster/'
 print('Uploading original data to S3.')
 # Upload raw data file to S3
 uploaded = util_cloud.aws_upload(raw_data_file, aws_bucket, s3_prefix+os.path.basename(raw_data_file))

--- a/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
+++ b/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
@@ -152,19 +152,8 @@ logger.addHandler(console)
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 logger.info('Executing script for dataset: ' + dataset_name)
-
-# set up Google Cloud Storage project and bucket objects
-gcs_client = storage.Client(os.environ.get("CLOUDSDK_CORE_PROJECT"))
-gcs_bucket = gcs_client.bucket(os.environ.get("GEE_STAGING_BUCKET"))
-
-# initialize ee and eeUtil modules for uploading to Google Earth Engine
-auth = ee.ServiceAccountCredentials(os.getenv('GEE_SERVICE_ACCOUNT'), os.getenv('GOOGLE_APPLICATION_CREDENTIALS'))
-ee.Initialize(auth)
-
-# amazon storage info
-aws_bucket = 'wri-projects'
-s3_prefix = 'resourcewatch/raster/'
-
+# create a new sub-directory within your specified dir called 'data'
+# within this directory, create files to store raw and processed data
 data_dir = util_files.prep_dirs(dataset_name)
 logger.debug('Data directory relative path: '+data_dir)
 logger.debug('Data directory absolute path: '+os.path.abspath(data_dir))

--- a/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
+++ b/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
@@ -213,7 +213,11 @@ Upload processed data to Google Earth Engine
 '''
 
 logger.info('Uploading processed data to Google Cloud Storage.')
-gcs_uris = util_cloud.gcs_upload(multitif, dataset_name, gcs_bucket=gcs_bucket)
+# set up Google Cloud Storage project and bucket objects
+gcsClient = storage.Client(os.environ.get("CLOUDSDK_CORE_PROJECT"))
+gcsBucket = gcsClient.bucket(os.environ.get("GEE_STAGING_BUCKET"))
+
+gcs_uris = util_cloud.gcs_upload(multitif, dataset_name, gcs_bucket=gcsBucket )
 
 logger.info('Uploading processed data to Google Earth Engine.')
 # initialize ee module for uploading to Google Earth Engine

--- a/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
+++ b/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
@@ -227,6 +227,13 @@ task_id = util_cloud.gee_ingest(manifest, public=True)
 util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcs_bucket)
 logger.info('Files deleted from Google Cloud Storage.')
 
+'''
+Upload original data and processed data to Amazon S3 storage
+'''
+
+# initialize AWS variables
+aws_bucket = 'wri-projects'
+s3_prefix = 'resourcewatch/raster/'
 logger.info('Uploading original data to S3.')
 # Upload raw data file to S3
 

--- a/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
+++ b/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
@@ -1,5 +1,4 @@
 # # RW Data Script: ocn_007_coral_bleaching_monitoring  
-# [Metadata](https://docs.google.com/document/d/1JFncI1CT1kvy1YB83gCm4aV_X_c-Hxt41epLB_jX2T0/edit)  
 # [Info](https://coralreefwatch.noaa.gov/product/5km/index.php)  
 # [Sources](ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1/nc/v1.0/daily/)  
 # 

--- a/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
+++ b/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
@@ -184,8 +184,8 @@ else:
 target_year = target_date.strftime('%Y')
 target_date = target_date.strftime('%Y%m%d')
 # can manual override date to test script when server is not updating
-# target_year = '2020'
-# target_date = '20200623'
+target_year = '2020'
+target_date = '20200623'
 
 for key, val in data_dict.items():
     val['url'] = val['url_template'].format(target_year, target_date)

--- a/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
+++ b/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
@@ -1,0 +1,255 @@
+# # RW Data Script: ocn_007_coral_bleaching_monitoring  
+# [Metadata](https://docs.google.com/document/d/1JFncI1CT1kvy1YB83gCm4aV_X_c-Hxt41epLB_jX2T0/edit)  
+# [Info](https://coralreefwatch.noaa.gov/product/5km/index.php)  
+# [Sources](ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1/nc/v1.0/daily/)  
+# 
+# Author: Peter Kerins  
+# Date: 2020 Jun 23  
+
+# ### Import
+
+import os
+import sys
+import dotenv
+dotenv.load_dotenv(os.path.abspath(os.getenv('RW_ENV')))
+if os.getenv('PROCESSING_DIR') not in sys.path:
+    sys.path.append(os.path.abspath(os.getenv('PROCESSING_DIR')))
+import util_files
+import util_cloud
+import urllib
+from zipfile import ZipFile
+import ee
+import subprocess
+from google.cloud import storage
+import time
+import logging
+from pprint import pprint
+from collections import OrderedDict 
+# dataset-specific imports
+import datetime
+import numpy as np
+
+# ### Set dataset-specific variables
+
+# name of asset on GEE where you want to upload data
+# this should be an asset name that is not currently in use
+dataset_name = 'ocn_007_coral_bleaching_monitoring'
+
+# this dataset requires acquiring several separate netcdf files
+# file path examples:
+# baa:  ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1/nc/v1.0/daily/baa-max-7d/2020/ct5km_baa-max-7d_v3.1_20200623.nc
+# hs:   ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1/nc/v1.0/daily/hs/2020/ct5km_hs_v3.1_20200622.nc
+# dhw:  ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1/nc/v1.0/daily/dhw/2020/ct5km_dhw_v3.1_20200622.nc
+# ssta: ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1/nc/v1.0/daily/ssta/2020/ct5km_ssta_v3.1_20200622.nc
+# sst:  ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/coraltemp/v1.0/nc/2020/coraltemp_v1.0_20200622.nc
+# sstt: ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1/nc/v1.0/daily/sst-trend-7d/2020/ct5km_sst-trend-7d_v3.1_20200622.nc
+
+# note that all netcdfs contain a "mask" subdataset, but it is the same for each so does not need to be extracted
+data_dict = OrderedDict()
+data_dict['bleaching_alert_area_7d'] = {
+        'url_template': 'ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1/nc/v1.0/daily/baa-max-7d/{}/ct5km_baa-max-7d_v3.1_{}.nc',
+        'sds': [
+            'bleaching_alert_area',
+        ],
+        'missing_data': [
+            -5,
+            251,
+        ],
+        'pyramiding_policy': 'MEAN',
+    }
+data_dict['hotspots'] = {
+        'url_template': 'ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1/nc/v1.0/daily/hs/{}/ct5km_hs_v3.1_{}.nc',
+        'sds': [
+            'hotspot',
+        ],
+        'missing_data': [
+            -32768,
+        ],
+        'pyramiding_policy': 'MEAN',
+        'scale_factor': 0.0099999998,
+    }
+data_dict['degree_heating_week'] = {
+        'url_template': 'ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1/nc/v1.0/daily/dhw/{}/ct5km_dhw_v3.1_{}.nc',
+        'sds': [
+            'degree_heating_week',
+        ],
+        'missing_data': [
+            -32768,
+        ],
+        'pyramiding_policy': 'MEAN',
+        'scale_factor': 0.0099999998,
+    }
+data_dict['sea_surface_temperature_anomaly'] = {
+        'url_template': 'ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1/nc/v1.0/daily/ssta/{}/ct5km_ssta_v3.1_{}.nc',
+        'sds': [
+            'sea_surface_temperature_anomaly',
+        ],
+        'missing_data': [
+            -32768,
+        ],
+        'pyramiding_policy': 'MEAN',
+        'scale_factor': 0.0099999998,
+    }
+data_dict['sea_surface_temperature'] = {
+        'url_template': 'ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/coraltemp/v1.0/nc/{}/coraltemp_v1.0_{}.nc',
+        'sds': [
+            'analysed_sst',
+        ],
+        'missing_data': [
+            -32768,
+        ],
+        'pyramiding_policy': 'MEAN',
+        'scale_factor': 0.01,
+    }
+data_dict['sea_surface_temperature_trend_7d'] = {
+        'url_template': 'ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1/nc/v1.0/daily/sst-trend-7d/{}/ct5km_sst-trend-7d_v3.1_{}.nc',
+        'sds': [
+            'trend',
+        ],
+        'missing_data': [
+            -32768,
+        ],
+        'pyramiding_policy': 'MEAN',
+        'scale_factor': 0.0099999998,
+    }
+
+
+# baa original: -5=No Data (land); 0=No Stress; 1=Watch; 2=Warning; 3=Alert Level 1; 4=Alert Level 2
+#     valid range [0,4]
+#     fill value -5
+#     scalefactor = 1
+# hs original: from low negatives up to about 10(C). scale bar from 0-5. nodata=nodata(land)
+#     valid range [-1500,1500]
+#     fill value -32768
+#     scalefactor = 0.0099999998
+# dhw original
+#     valid range [0,10000]
+#     fill value -32768
+#     scalefactor = 0.0099999998
+# sst anomaly
+#     valid range [-1500,1500]
+#     fill value -32768
+#     scalefactor = 0.0099999998
+# sst
+#     valid range [-200,5000]
+#     fill value -32768
+#     scale_factor=0.01
+# sst trend
+#     valid range [-1500,1500]
+#     fill value -32768
+#     scale_factor=0.0099999998
+
+
+# ### Set/initialize/authenticate general variables
+
+# Get the top-level logger object
+logger = logging.getLogger()
+for handler in logger.handlers: logger.removeHandler(handler)
+logger.setLevel(logging.INFO)
+# make it print to the console.
+console = logging.StreamHandler()
+logger.addHandler(console)
+logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+logger.info('Executing script for dataset: ' + dataset_name)
+
+# set up Google Cloud Storage project and bucket objects
+gcs_client = storage.Client(os.environ.get("CLOUDSDK_CORE_PROJECT"))
+gcs_bucket = gcs_client.bucket(os.environ.get("GEE_STAGING_BUCKET"))
+
+# initialize ee and eeUtil modules for uploading to Google Earth Engine
+auth = ee.ServiceAccountCredentials(os.getenv('GEE_SERVICE_ACCOUNT'), os.getenv('GOOGLE_APPLICATION_CREDENTIALS'))
+ee.Initialize(auth)
+
+# amazon storage info
+aws_bucket = 'wri-projects'
+s3_prefix = 'resourcewatch/raster/'
+
+data_dir = util_files.prep_dirs(dataset_name)
+logger.debug('Data directory relative path: '+data_dir)
+logger.debug('Data directory absolute path: '+os.path.abspath(data_dir))
+
+# create request urls
+# previous day's data appears on server just before 11am (ET?)
+now = datetime.datetime.now()
+now_hour = int(now.strftime('%H'))
+
+if now_hour >= 11:
+    logger.info('Targeting data from yesterday (script running after 11am)')
+    target_date = now - datetime.timedelta(days=1)
+else:
+    logger.info('Targeting data from day before yesterday (script running before 11am)')
+    target_date = now - datetime.timedelta(days=2)
+
+target_year = target_date.strftime('%Y')
+target_date = target_date.strftime('%Y%m%d')
+# can manual override date to test script when server is not updating
+# target_year = '2020'
+# target_date = '20200623'
+
+for key, val in data_dict.items():
+    val['url'] = val['url_template'].format(target_year, target_date)
+
+logger.info('Downloading raw data')
+for key, val in data_dict.items():
+    url = val['url']
+    raw_data_file = os.path.join(data_dir,os.path.basename(url))
+    urllib.request.urlretrieve(url, raw_data_file)
+    val['raw_data_file'] = raw_data_file
+    logger.debug('('+key+')'+'Raw data file path: ' + raw_data_file)
+
+logger.info('Extracting relevant GeoTIFFs from source NetCDFs')
+for key, val in data_dict.items():
+    val['tifs'] = util_files.convert_netcdf(val['raw_data_file'], val['sds'])
+
+# no masking necessary, in theory
+# do need to scale most of the datasets though
+alltifs = []
+for key, val in data_dict.items():
+    if 'scale_factor' in val and float(val['scale_factor'] != 1.0):
+        finaltifs = []
+        for tif in val['tifs']:
+            finaltifs.append(util_files.scale_geotiff(tif))
+    else:
+        finaltifs = val['tifs']
+    val['finaltifs'] = finaltifs
+    alltifs.extend(finaltifs)
+
+logger.info('Merging masked, single-band GeoTIFFs into single, multiband GeoTIFF.')
+multitif = os.path.abspath(os.path.join(data_dir,dataset_name+'.tif'))
+util_files.merge_geotiffs(alltifs, multitif, ot='float32')
+processed_data_file = multitif
+
+logger.info('Uploading processed data to Google Cloud Storage.')
+gcs_uris = util_cloud.gcs_upload(multitif, dataset_name, gcs_bucket=gcs_bucket)
+
+logger.info('Uploading processed data to Google Earth Engine.')
+# name bands according to variable names in original netcdf
+mf_bands = util_cloud.gee_manifest_bands(data_dict, dataset_name)
+# Upload processed data file to GEE
+asset_name = f'projects/resource-watch-gee/{dataset_name}'
+
+manifest = util_cloud.gee_manifest_complete(asset_name, gcs_uris[0], mf_bands)
+task_id = util_cloud.gee_ingest(manifest, public=True)
+
+util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcs_bucket)
+logger.info('Files deleted from Google Cloud Storage.')
+
+logger.info('Uploading original data to S3.')
+# Upload raw data file to S3
+
+# Copy the raw data into a zipped file to upload to S3
+raw_data_dir = os.path.join(data_dir, dataset_name+'.zip')
+with ZipFile(raw_data_dir,'w') as zip:
+    for key, val in data_dict.items():
+        raw_data_file = val['raw_data_file']
+        zip.write(raw_data_file, os.path.basename(raw_data_file))
+uploaded = util_cloud.aws_upload(raw_data_dir, aws_bucket, s3_prefix+os.path.basename(raw_data_dir))
+
+logger.info('Uploading processed data to S3.')
+# Copy the processed data into a zipped file to upload to S3
+processed_data_dir = os.path.join(data_dir, dataset_name+'_edit.zip')
+with ZipFile(processed_data_dir,'w') as zip:
+    zip.write(processed_data_file, os.path.basename(processed_data_file))
+# Upload processed data file to S3
+uploaded = util_cloud.aws_upload(processed_data_dir, aws_bucket, s3_prefix+os.path.basename(processed_data_dir))

--- a/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
+++ b/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
@@ -213,6 +213,10 @@ logger.info('Uploading processed data to Google Cloud Storage.')
 gcs_uris = util_cloud.gcs_upload(multitif, dataset_name, gcs_bucket=gcs_bucket)
 
 logger.info('Uploading processed data to Google Earth Engine.')
+# initialize ee module for uploading to Google Earth Engine
+auth = ee.ServiceAccountCredentials(os.getenv('GEE_SERVICE_ACCOUNT'), os.getenv('GOOGLE_APPLICATION_CREDENTIALS'))
+ee.Initialize(auth)
+
 # name bands according to variable names in original netcdf
 mf_bands = util_cloud.gee_manifest_bands(data_dict, dataset_name)
 # Upload processed data file to GEE

--- a/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
+++ b/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
@@ -232,7 +232,7 @@ asset_name = f'projects/resource-watch-gee/{dataset_name}'
 manifest = util_cloud.gee_manifest_complete(asset_name, gcs_uris[0], mf_bands)
 task_id = util_cloud.gee_ingest(manifest, public=True)
 
-util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcs_bucket)
+util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcsBucket)
 logger.info('Files deleted from Google Cloud Storage.')
 
 '''

--- a/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
+++ b/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring.py
@@ -208,6 +208,10 @@ multitif = os.path.abspath(os.path.join(data_dir,dataset_name+'.tif'))
 util_files.merge_geotiffs(alltifs, multitif, ot='float32')
 processed_data_file = multitif
 
+'''
+Upload processed data to Google Earth Engine
+'''
+
 logger.info('Uploading processed data to Google Cloud Storage.')
 gcs_uris = util_cloud.gcs_upload(multitif, dataset_name, gcs_bucket=gcs_bucket)
 

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -59,21 +59,8 @@ logger.addHandler(console)
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 logger.info('Executing script for dataset: ' + dataset_name)
-
-# set up Google Cloud Storage project and bucket objects
-gcs_client = storage.Client(os.environ.get("CLOUDSDK_CORE_PROJECT"))
-gcs_bucket = gcs_client.bucket(os.environ.get("GEE_STAGING_BUCKET"))
-
-# initialize ee and eeUtil modules for uploading to Google Earth Engine
-auth = ee.ServiceAccountCredentials(os.getenv('GEE_SERVICE_ACCOUNT'), os.getenv('GOOGLE_APPLICATION_CREDENTIALS'))
-ee.Initialize(auth)
-
-# amazon storage info
-aws_bucket = 'wri-projects'
-s3_prefix = 'resourcewatch/raster/'
-
-# ## Execution
-
+# create a new sub-directory within your specified dir called 'data'
+# within this directory, create files to store raw and processed data
 data_dir = util_files.prep_dirs(dataset_name)
 logger.debug('Data directory relative path: '+data_dir)
 logger.debug('Data directory absolute path: '+os.path.abspath(data_dir))
@@ -142,4 +129,3 @@ with ZipFile(processed_data_dir,'w') as zip:
     zip.write(processed_data_file, os.path.basename(processed_data_file))
 # Upload processed data file to S3
 uploaded = util_cloud.aws_upload(processed_data_dir, aws_bucket, s3_prefix+os.path.basename(processed_data_dir))
-

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -43,10 +43,6 @@ subdatasets = ['stdv_maxmonth',
 band_ids = ['stdv_maxmonth',
             'stdv_annual',
            ]
-
-# set pyramiding policy for GEE upload
-pyramiding_policy = 'MEAN' #check
-
 # ### Set/initialize/authenticate general variables
 
 # Get the top-level logger object

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -98,7 +98,11 @@ Upload processed data to Google Earth Engine
 '''
 
 logger.info('Uploading processed data to Google Cloud Storage.')
-gcs_uris= util_cloud.gcs_upload(multitif, dataset_name, gcs_bucket=gcs_bucket)
+# set up Google Cloud Storage project and bucket objects
+gcsClient = storage.Client(os.environ.get("CLOUDSDK_CORE_PROJECT"))
+gcsBucket = gcsClient.bucket(os.environ.get("GEE_STAGING_BUCKET"))
+
+gcs_uris= util_cloud.gcs_upload(multitif, dataset_name, gcs_bucket=gcsBucket)
 
 logger.info('Uploading processed data to Google Earth Engine.')
 # initialize ee and eeUtil modules for uploading to Google Earth Engine

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -110,18 +110,20 @@ util_files.merge_geotiffs(masked_tifs, multitif)
 processed_data_file = multitif
 
 logger.info('Uploading processed data to Google Cloud Storage.')
-gcs_uri= util_cloud.gcs_upload(multitif, dataset_name, gcs_bucket=gcs_bucket)
+gcs_uris= util_cloud.gcs_upload(multitif, dataset_name, gcs_bucket=gcs_bucket)
 
 logger.info('Uploading processed data to Google Earth Engine.')
 # name bands according to variable names in original netcdf
-bands = [{'id': band_id, 'tileset_band_index': band_ids.index(band_id), 'tileset_id': dataset_name, 'pyramidingPolicy': pyramiding_policy} for band_id in band_ids]
+mf_bands = [{'id': band_id, 'tileset_band_index': band_ids.index(band_id), 'tileset_id': dataset_name, 'pyramidingPolicy': pyramiding_policy} for band_id in band_ids]
 
 # Upload processed data file to GEE
 asset_name = f'projects/resource-watch-gee/{dataset_name}'
+manifest = util_cloud.gee_manifest_complete(asset_name, gcs_uris[0], mf_bands)
+task_id = util_cloud.gee_ingest(manifest, public=True)
 
-task_id = util_cloud.gee_ingest(gcs_uri[0], asset=asset_name, bands=bands, public=True)
+task_id = util_cloud.gee_ingest(manifest, public=True)
 
-util_cloud.gcs_remove(gcs_uri, gcs_bucket=gcs_bucket)
+util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcs_bucket)
 logger.info('Files deleted from Google Cloud Storage.')
 
 logger.info('Uploading original data to S3.')

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -34,6 +34,7 @@ import logging
 # this should be an asset name that is not currently in use
 dataset_name = 'ocn_009_sea_surface_temperature_variability'
 
+# netcdf subdatasets that will be used in processing
 subdatasets = ['stdv_maxmonth',
                'stdv_annual',
                'mask',

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -100,6 +100,13 @@ logger.info('Uploading processed data to Google Cloud Storage.')
 gcs_uris= util_cloud.gcs_upload(multitif, dataset_name, gcs_bucket=gcs_bucket)
 
 logger.info('Uploading processed data to Google Earth Engine.')
+# initialize ee and eeUtil modules for uploading to Google Earth Engine
+auth = ee.ServiceAccountCredentials(os.getenv('GEE_SERVICE_ACCOUNT'), os.getenv('GOOGLE_APPLICATION_CREDENTIALS'))
+ee.Initialize(auth)
+
+# set pyramiding policy for GEE upload
+pyramiding_policy = 'MEAN' #check
+           
 # name bands according to variable names in original netcdf
 mf_bands = [{'id': band_id, 'tileset_band_index': band_ids.index(band_id), 'tileset_id': dataset_name, 'pyramidingPolicy': pyramiding_policy} for band_id in band_ids]
 

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# # RW Data Script: ocn_009_sea_surface_temperature_variability
+# [Metadata](https://docs.google.com/document/d/1qIEaMfgPzo8IGBMut6EnaZi9J3xo42GgAiJh5VIjnLY/edit)  
+# [Info](https://coralreefwatch.noaa.gov/product/thermal_history/sst_variability.php)  
+# [Source](ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/thermal_history/v2.1)  
+# 
+# Author: Peter Kerins  
+# Date: 2020 Jun 18  
+
+# ### Import
+
+import os
+import sys
+import dotenv
+dotenv.load_dotenv(os.path.abspath(os.getenv('RW_ENV')))
+if os.getenv('PROCESSING_DIR') not in sys.path:
+    sys.path.append(os.path.abspath(os.getenv('PROCESSING_DIR')))
+import util_files
+import util_cloud
+import urllib
+from zipfile import ZipFile
+import ee
+import subprocess
+from google.cloud import storage
+from shutil import copyfile
+import time
+import logging
+
+
+# ### Set dataset-specific variables
+
+# name of asset on GEE where you want to upload data
+# this should be an asset name that is not currently in use
+dataset_name = 'ocn_009_sea_surface_temperature_variability'
+
+subdatasets = ['stdv_warmseason',
+               'stdv_annual',
+               'mask',
+              ]
+
+band_ids = ['stdv_warmseason',
+            'stdv_annual',
+           ]
+
+# set pyramiding policy for GEE upload
+pyramiding_policy = 'MEAN' #check
+
+# ### Set/initialize/authenticate general variables
+
+# Get the top-level logger object
+logger = logging.getLogger()
+for handler in logger.handlers: logger.removeHandler(handler)
+logger.setLevel(logging.INFO)
+# make it print to the console.
+console = logging.StreamHandler()
+logger.addHandler(console)
+logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+logger.info('Executing script for dataset: ' + dataset_name)
+
+# set up Google Cloud Storage project and bucket objects
+gcs_client = storage.Client(os.environ.get("CLOUDSDK_CORE_PROJECT"))
+gcs_bucket = gcs_client.bucket(os.environ.get("GEE_STAGING_BUCKET"))
+
+# initialize ee and eeUtil modules for uploading to Google Earth Engine
+auth = ee.ServiceAccountCredentials(os.getenv('GEE_SERVICE_ACCOUNT'), os.getenv('GOOGLE_APPLICATION_CREDENTIALS'))
+ee.Initialize(auth)
+
+# amazon storage info
+aws_bucket = 'wri-projects'
+s3_prefix = 'resourcewatch/raster/'
+
+# ## Execution
+
+data_dir = util_files.prep_dirs(dataset_name)
+logger.debug('Data directory relative path: '+data_dir)
+logger.debug('Data directory absolute path: '+os.path.abspath(data_dir))
+logger.info('Downloading raw data')
+
+url='ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/thermal_history/v2.1/noaa_crw_thermal_history_sst_variability_v2.1.nc'
+raw_data_file = os.path.join(data_dir,os.path.basename(url))
+urllib.request.urlretrieve(url, raw_data_file)
+
+logger.debug('Raw data file path: ' + raw_data_file)
+
+logger.info('Extracting relevant GeoTIFFs from source NetCDF')
+
+tifs = util_files.convert_netcdf(raw_data_file, subdatasets)
+
+logger.info('Mask extracted GeoTIFFs using dataset mask')
+# create dict linking subdatasets from the netcdf to the geotiffs that now contain each
+sds_file_dict=dict(zip(subdatasets,tifs))
+# set nodata value for masking
+nodata=-128
+
+# cycle through target tifs (corresponding to bands) and mask them with mask tif
+masked_tifs = []
+for band_id in band_ids:
+    sds_file = sds_file_dict[band_id]
+    band_masked = sds_file[:sds_file.find('.tif')] + '_masked.tif'
+    util_files.mask_geotiff(sds_file_dict[band_id], sds_file_dict['mask'], band_masked, nodata=nodata)
+    masked_tifs.append(band_masked)
+    
+logger.info('Merge masked, single-band GeoTIFFs into single, multiband GeoTIFF.')
+# merge multiple masked single-band tifs as layers in single multiband tif
+multitif = os.path.abspath(os.path.join(data_dir,dataset_name+'.tif'))
+util_files.merge_geotiffs(masked_tifs, multitif)
+processed_data_file = multitif
+
+logger.info('Uploading processed data to Google Cloud Storage.')
+gcs_uri= util_cloud.gcs_upload(multitif, dataset_name, gcs_bucket=gcs_bucket)
+
+logger.info('Uploading processed data to Google Earth Engine.')
+# name bands according to variable names in original netcdf
+bands = [{'id': band_id, 'tileset_band_index': band_ids.index(band_id), 'tileset_id': dataset_name, 'pyramidingPolicy': pyramiding_policy} for band_id in band_ids]
+
+# Upload processed data file to GEE
+asset_name = f'projects/resource-watch-gee/{dataset_name}'
+
+task_id = util_cloud.gee_ingest(gcs_uri[0], asset=asset_name, bands=bands, public=True)
+
+util_cloud.gcs_remove(gcs_uri, gcs_bucket=gcs_bucket)
+logger.info('Files deleted from Google Cloud Storage.')
+
+logger.info('Uploading original data to S3.')
+# Upload raw data file to S3
+
+# Copy the raw data into a zipped file to upload to S3
+raw_data_dir = os.path.join(data_dir, dataset_name+'.zip')
+with ZipFile(raw_data_dir,'w') as zip:
+    zip.write(raw_data_file, os.path.basename(raw_data_file))
+uploaded = util_cloud.aws_upload(raw_data_dir, aws_bucket, s3_prefix+os.path.basename(raw_data_dir))
+
+logger.info('Uploading processed data to S3.')
+# Copy the processed data into a zipped file to upload to S3
+processed_data_dir = os.path.join(data_dir, dataset_name+'_edit.zip')
+with ZipFile(processed_data_dir,'w') as zip:
+    zip.write(processed_data_file, os.path.basename(processed_data_file))
+# Upload processed data file to S3
+uploaded = util_cloud.aws_upload(processed_data_dir, aws_bucket, s3_prefix+os.path.basename(processed_data_dir))
+

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -2,7 +2,6 @@
 # coding: utf-8
 
 # # RW Data Script: ocn_009_sea_surface_temperature_variability
-# [Metadata](https://docs.google.com/document/d/1qIEaMfgPzo8IGBMut6EnaZi9J3xo42GgAiJh5VIjnLY/edit)  
 # [Info](https://coralreefwatch.noaa.gov/product/thermal_history/sst_variability.php)  
 # [Source](ftp://ftp.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/thermal_history/v2.1)  
 # 

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -122,7 +122,7 @@ task_id = util_cloud.gee_ingest(manifest, public=True)
 
 task_id = util_cloud.gee_ingest(manifest, public=True)
 
-util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcs_bucket)
+util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcsBucket)
 logger.info('Files deleted from Google Cloud Storage.')
 
 '''

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -40,6 +40,7 @@ subdatasets = ['stdv_maxmonth',
                'mask',
               ]
 
+# nedcdf subdatasets that will be uploaded as bands to GEE
 band_ids = ['stdv_maxmonth',
             'stdv_annual',
            ]

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -93,6 +93,10 @@ multitif = os.path.abspath(os.path.join(data_dir,dataset_name+'.tif'))
 util_files.merge_geotiffs(masked_tifs, multitif)
 processed_data_file = multitif
 
+'''
+Upload processed data to Google Earth Engine
+'''
+
 logger.info('Uploading processed data to Google Cloud Storage.')
 gcs_uris= util_cloud.gcs_upload(multitif, dataset_name, gcs_bucket=gcs_bucket)
 

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -35,12 +35,12 @@ import logging
 # this should be an asset name that is not currently in use
 dataset_name = 'ocn_009_sea_surface_temperature_variability'
 
-subdatasets = ['stdv_warmseason',
+subdatasets = ['stdv_maxmonth',
                'stdv_annual',
                'mask',
               ]
 
-band_ids = ['stdv_warmseason',
+band_ids = ['stdv_maxmonth',
             'stdv_annual',
            ]
 

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability.py
@@ -117,6 +117,13 @@ task_id = util_cloud.gee_ingest(manifest, public=True)
 util_cloud.gcs_remove(gcs_uris, gcs_bucket=gcs_bucket)
 logger.info('Files deleted from Google Cloud Storage.')
 
+'''
+Upload original data and processed data to Amazon S3 storage
+'''
+
+# initialize AWS variables
+aws_bucket = 'wri-projects'
+s3_prefix = 'resourcewatch/raster/'
 logger.info('Uploading original data to S3.')
 # Upload raw data file to S3
 

--- a/util_cloud.py
+++ b/util_cloud.py
@@ -89,8 +89,8 @@ def gee_manifest_complete(asset, gcs_uri, mf_bands, date=''):
               'tilesets': [{'id': os.path.basename(gcs_uri).split('.')[0], 'sources': [{'uris': gcs_uri}]}]}
     # if a date was input into the function, add it to the parameters
     if date:
-        manifest['properties'] = {'time_start': formatDate(date),
-                                'time_end': formatDate(date)}
+        manifest['properties'] = {'time_start': millis_since_epoch(date),
+                                'time_end': millis_since_epoch(date)}
     manifest['bands'] = mf_bands
     return manifest
 

--- a/util_cloud.py
+++ b/util_cloud.py
@@ -41,6 +41,17 @@ def gcs_upload(files, prefix='', gcs_bucket=None):
         gcs_uris.append(uri)
     return gcs_uris
 
+def millis_since_epoch(date):
+    '''
+    Format date as milliseconds since last epoch
+    INPUT   date: datetime to be converted (datetime)
+    RETURN date in milliseconds since last epoch (integer)
+    '''
+    if isinstance(date, int):
+        return date
+    seconds = (date - datetime.datetime.utcfromtimestamp(0)).total_seconds()
+    return int(seconds * 1000)
+    
 def gee_manifest_bands(bands_dict, dataset_name):
     '''
     Create bands manifest for image upload to GEE (https://developers.google.com/earth-engine/image_manifest)

--- a/util_cloud.py
+++ b/util_cloud.py
@@ -1,0 +1,117 @@
+import os
+import dotenv
+dotenv.load_dotenv(os.getenv('RW_ENV'))
+import boto3
+from botocore.exceptions import NoCredentialsError
+import time
+import ee
+from google.cloud import storage
+
+def gcs_upload(files, prefix='', gcs_bucket=None):
+    '''
+    Upload files to Google Cloud Storage
+    INPUT   files: location of file on local computer that you want to upload (string)
+            prefix: optional, folder within GCS bucket where you want to upload the data (string)
+    RETURN  gcs_uris: list of uploaded data file locations on GCS (list of strings)
+    '''
+    # make sure the GCS bucket exists, create it if it does not
+    if gcs_bucket is None:
+        print('No bucket passed, creating {}'.format(os.environ.get("GEE_STAGING_BUCKET")))
+        gcs_bucket = storage.Client(os.environ.get("CLOUDSDK_CORE_PROJECT")).bucket(os.environ.get("GEE_STAGING_BUCKET"))
+    elif not gcs_bucket.exists():
+        print('Bucket {} does not exist, creating'.format(os.environ.get("GEE_STAGING_BUCKET")))
+        gcs_bucket.create()
+    # make sure files to be uploaded are formatted as a tuple
+    files = (files,) if isinstance(files, str) else files
+    # create an empty list to store the list of files we have uploaded to GCS
+    gcs_uris = []
+    # loop through each file and upload
+    for f in files:
+        # define location within GCS bucket where the file should go
+        path = '{}/{}'.format(prefix, os.path.basename(f))
+        # format the full GCS path for the file
+        uri = 'gs://{}/{}'.format(gcs_bucket.name, path)
+        print('Uploading {} to {}'.format(f, uri))
+        # upload the file to GCS
+        gcs_bucket.blob(path).upload_from_filename(f)
+        # add the file location to our list of uploaded files
+        gcs_uris.append(uri)
+    return gcs_uris
+
+def gee_ingest(gcs_uri, asset, date='', bands=[], public=False):
+    '''
+    Upload asset from Google Cloud Storage to Google Earth Engine
+    INPUT   gcs_uri: data file location on GCS, should be formatted `gs://<bucket>/<blob>` (string)
+            asset: name of GEE asset destination path
+            date: optional, date tag for asset (datetime.datetime or int ms since epoch)
+            bands: optional, band name dictionary (list of dictionaries)
+            public: do you want this asset to be public (Boolean)
+    RETURN  task_id: Earth Engine task ID for file upload (string)
+    '''
+    # set up parameters for image task ingestion
+    params = {'name': f'projects/earthengine-legacy/assets/{asset}',
+              'tilesets': [{'id': os.path.basename(gcs_uri).split('.')[0], 'sources': [{'uris': gcs_uri}]}]}
+    # if a date was input into the function, add it to the parameters
+    if date:
+        params['properties'] = {'time_start': formatDate(date),
+                                'time_end': formatDate(date)}
+    # if band parameters were included add them to the parameters
+    if bands:
+        if isinstance(bands[0], str):
+            bands = [{'id': b} for b in bands]
+        params['bands'] = bands
+    # create a new task ID to ingest this asset
+    task_id = ee.data.newTaskId()[0]
+    print('Ingesting {} to {}: {}'.format(gcs_uri, asset, task_id))
+    # start ingestion process
+    uploaded = False
+    print(gcs_uri)
+    print(params)
+    ee.data.startIngestion(task_id, params, True)
+    # if process is still running, wait before checking ingestion again
+    while uploaded == False:
+        try:
+            ee.data.getAsset(asset)
+            uploaded = True
+            print('GEE asset created: {}'.format(asset))
+        except:
+            time.sleep(30)
+    if public==True:
+        # set dataset privacy to public
+        acl = {"all_users_can_read": True}
+        ee.data.setAssetAcl(asset, acl)
+        print('Privacy set to public.')
+    return task_id
+
+def gcs_remove(gcs_uris, gcs_bucket=None):
+    '''
+    Delete files from Google Cloud Storage
+    INPUT   gcs_uris: list of data file locations on GCS that you want to delete (list of strings)
+    '''
+    # make sure the GCS bucket exists, create it if it does not
+    if gcs_bucket is None:
+        print('No bucket passed, creating {}'.format(os.environ.get("GEE_STAGING_BUCKET")))
+        gcs_bucket = storage.Client(os.environ.get("CLOUDSDK_CORE_PROJECT")).bucket(os.environ.get("GEE_STAGING_BUCKET"))
+    elif not gcs_bucket.exists():
+        print('Bucket {} does not exist, creating'.format(os.environ.get("GEE_STAGING_BUCKET")))
+        gcs_bucket.create()
+    # create a list of the files in Google Cloud Storage that should be deleted
+    paths = []
+    for path in gcs_uris:
+        paths.append(path[6 + len(gcs_bucket.name):])
+    # delete all files from Google Cloud Storage
+    gcs_bucket.delete_blobs(paths, lambda x:x)
+    
+def aws_upload(local_file, bucket, s3_file):
+    s3 = boto3.client('s3', aws_access_key_id=os.getenv('aws_access_key_id'), aws_secret_access_key=os.getenv('aws_secret_access_key'))
+    try:
+        s3.upload_file(local_file, bucket, s3_file)
+        print("Upload Successful")
+        print("http://{}.s3.amazonaws.com/{}".format(bucket, s3_file))
+        return True
+    except FileNotFoundError:
+        print("The file was not found")
+        return False
+    except NoCredentialsError:
+        print("Credentials not available")
+        return False

--- a/util_cloud.py
+++ b/util_cloud.py
@@ -42,6 +42,12 @@ def gcs_upload(files, prefix='', gcs_bucket=None):
     return gcs_uris
 
 def gee_manifest_bands(bands_dict, dataset_name):
+    '''
+    Create bands manifest for image upload to GEE (https://developers.google.com/earth-engine/image_manifest)
+    INPUT   bands_dict: dictionary in which keys are band names and values are dictionaries containing a list of no-data values and the pyramiding policy to use in Google Earth Engine (dictionary)
+            dataset_name: name of the asset being uploaded to GEE (string)
+    RETURN  bands_mf: band manifest for asset upload into GEE, in the form of a list of dictionaries, with each dictionary containing parameters for an image band (list of dictionaries)
+    '''
     bands_mf = []
     i = 0
     for key, val in bands_dict.items():

--- a/util_cloud.py
+++ b/util_cloud.py
@@ -65,6 +65,14 @@ def gee_manifest_bands(bands_dict, dataset_name):
     return bands_mf
 
 def gee_manifest_complete(asset, gcs_uri, mf_bands, date=''):
+    '''
+    Create complete manifest for image upload to GEE (https://developers.google.com/earth-engine/image_manifest)
+    INPUT   asset: name of the asset being uploaded to GEE (string)
+            gs_uri: data file location on GCS, should be formatted `gs://<bucket>/<blob>` (string)
+            mf_bands: band manifest, created with gee_manifest_bands function (dictionary)
+            date: optional, date tag for asset (datetime.datetime or int ms since epoch)
+    RETURN  manifest: complete manifest for asset upload into GEE (dictionary)
+    '''
     # set up parameters for image task ingestion
     manifest = {'name': f'projects/earthengine-legacy/assets/{asset}',
               'tilesets': [{'id': os.path.basename(gcs_uri).split('.')[0], 'sources': [{'uris': gcs_uri}]}]}

--- a/util_cloud.py
+++ b/util_cloud.py
@@ -131,6 +131,12 @@ def gcs_remove(gcs_uris, gcs_bucket=None):
     gcs_bucket.delete_blobs(paths, lambda x:x)
     
 def aws_upload(local_file, bucket, s3_file):
+    '''
+    Upload original data and processed data to Amazon S3 storage
+    INPUT   local_file: local file to be uploaded to AWS (string)
+        bucket: AWS bucket where file should be uploaded (string)
+        s3_file: path where file should be uploaded within the input AWS bucket (string)
+    '''
     s3 = boto3.client('s3', aws_access_key_id=os.getenv('aws_access_key_id'), aws_secret_access_key=os.getenv('aws_secret_access_key'))
     try:
         s3.upload_file(local_file, bucket, s3_file)

--- a/util_files.py
+++ b/util_files.py
@@ -109,6 +109,7 @@ def scale_geotiff(tif, scaledtif=None, scale_factor=None, nodata=None, gdal_type
             scale_factor: scale factor to be applied; if None, value is drawn from metadata (numeric)
             nodata: value to indicate no data in output raster; if None, original value is used (numeric)
             gdal_type: GDAL numeric type of the output raster (gdalconst(int))
+    RETURN scaledtif: filename of scaled output raster (string)
     '''
     geotiff = gdal.Open(tif, gdal.gdalconst.GA_ReadOnly)
     assert (geotiff.RasterCount == 1)

--- a/util_files.py
+++ b/util_files.py
@@ -3,6 +3,8 @@ import sys
 import dotenv
 dotenv.load_dotenv(os.getenv('RW_ENV'))
 import subprocess
+import gdal
+import numpy as np
 import logging
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
@@ -75,18 +77,120 @@ def mask_geotiff(target, mask, maskedtif, nodata=-128):
 #     !gdal_calc.py -A {annual} -B {mask} --outfile={annual_masked} --calc="((B==0)*{nodata})+((B==1)*A)"
     return    
                   
-def merge_geotiffs(tifs, multitif):
+def merge_geotiffs(tifs, multitif, ot=None):
     '''
-    Merge input single-band geotiffs into one multi-band geotiff
+    Merge input single-band geotiffs into one multi-band geotiff. This is a "dumb" merge; for example,
+    it destroys all band metadata.
     INPUT   tifs: file names of all single-band geotiffs to merge (list of strings)
             multitif: file name of resulting, multi-band geotiff
     '''
     # merge all the sub tifs from this netcdf to create an overall tif representing all variable
     merge_path = os.path.abspath(os.path.join(os.getenv('GDAL_DIR'),'gdal_merge.py'))
-    cmd = '{} "{}" -separate {} -o {}'.format(sys.executable, merge_path, ' '.join(tifs), multitif)
+    cmd = '{} "{}" '
+    if ot is not None:
+        cmd += '-ot {} '.format(ot)
+    cmd += '-o {} -separate {} '
+    cmd = cmd.format(sys.executable, merge_path, multitif, ' '.join(tifs), )
     completed_process = subprocess.run(cmd, shell=False)
     logger.debug(str(completed_process))
     if completed_process.returncode!=0:
         raise Exception('Merging of GeoTiffs using gdal_merge.py failed! Command: '+str(cmd))
     return    
-                  
+              
+def scale_geotiff(tif, scaledtif=None, scale_factor=None, nodata=None, gdal_type=gdal.GDT_Float32):
+    '''
+    Apply scale factor to geotiff, writing the result to a new geotiff file. 
+    Raster values and linked metadata are changed; all other metadata are preserved.
+    This function's complexity comes from metadata preservation, and is written with an eye
+    towards typical NetCDF metadata contents and structure. If these elements are not relevant,
+    then gdal_edit.py or gdal_calc.py may be a simpler solution.
+    INPUT   tif: file name of single-band geotiff to be scaled (string)
+            scaledtif: file name of output raster; if None, input file name is appended (string)
+            scale_factor: scale factor to be applied; if None, value is drawn from metadata (numeric)
+            nodata: value to indicate no data in output raster; if None, original value is used (numeric)
+            gdal_type: GDAL numeric type of the output raster (gdalconst(int))
+    '''
+    geotiff = gdal.Open(tif, gdal.gdalconst.GA_ReadOnly)
+    assert (geotiff.RasterCount == 1)
+    band = geotiff.GetRasterBand(1)
+    
+    # read in raster
+    raster = np.array(band.ReadAsArray())    
+    
+    # retrieve nodata/fill from band metadata
+    # identify nodata entries in raster
+    nodata_mask = (raster == band.GetNoDataValue())
+    
+    # retrieve scale factor from band metadata
+    band_metadata = band.GetMetadata()
+    band_scale_keys = [key for key, val in band_metadata.items() if 'scale' in key.lower()]
+    assert (len(band_scale_keys)<=1)
+    band_fill_keys = [key for key, val in band_metadata.items() if 'fill' in key.lower()]
+    assert (len(band_fill_keys)<=1)
+    assert (float(band_metadata[band_fill_keys[0]])==band.GetNoDataValue())
+    if scale_factor is None:
+        scale_factor = float(band_metadata[band_scale_keys[0]])
+    
+    # apply scale factor to raster
+    logger.debug(f'Applying scale factor of {scale_factor} to raster of GeoTiff {os.path.basename(tif)}')
+    new_raster = raster * scale_factor
+    
+    # apply nodata fill as desired
+    if nodata is None:
+        nodata = band.GetNoDataValue()
+    new_raster[nodata_mask] = nodata
+    
+    # update band metadata
+    new_band_metadata = band_metadata.copy()
+    if len(band_scale_keys) > 0:
+        new_band_metadata[band_scale_keys[0]] = str(1)
+    if len(band_fill_keys) > 0:
+        new_band_metadata[band_fill_keys[0]] = str(nodata)
+    if 'valid_max' in new_band_metadata:
+        new_band_metadata['valid_max'] = str(float(band_metadata['valid_max']) * scale_factor)
+    if 'valid_min' in new_band_metadata:
+        new_band_metadata['valid_min'] = str(float(band_metadata['valid_min']) * scale_factor)
+    
+    # update geotiff metadata
+    ds_metadata = geotiff.GetMetadata()
+    ds_scale_keys = [key for key, val in ds_metadata.items() if 'scale' in key.lower()]
+    assert (len(ds_scale_keys)<=1)
+    metadata_band_prefix = ds_scale_keys[0].split('#')[0]
+    ds_fill_keys = [key for key, val in ds_metadata.items() if 'fill' in key.lower()]
+    assert (len(ds_fill_keys)<=1)
+    ds_valid_min_keys = [key for key, val in ds_metadata.items() if metadata_band_prefix.lower()+'#'+'valid_min' in key.lower()]
+    assert (len(ds_valid_min_keys)<=1)
+    ds_valid_max_keys = [key for key, val in ds_metadata.items() if metadata_band_prefix.lower()+'#'+'valid_max' in key.lower()]
+    assert (len(ds_valid_max_keys)<=1)
+    
+    new_ds_metadata = ds_metadata.copy()
+    if len(ds_scale_keys) > 0:
+        new_ds_metadata[ds_scale_keys[0]] = str(1)
+    if len(ds_fill_keys) > 0:
+        new_ds_metadata[ds_fill_keys[0]] = str(nodata)
+    if len(ds_valid_min_keys) > 0:
+        new_ds_metadata[ds_valid_min_keys[0]] = str(float(ds_metadata[ds_valid_min_keys[0]]) * scale_factor)
+    if len(ds_valid_max_keys) > 0:
+        new_ds_metadata[ds_valid_max_keys[0]] = str(float(ds_metadata[ds_valid_max_keys[0]]) * scale_factor)
+    
+    # create output dataset
+    # get output file name
+    if scaledtif is None:
+        dotindex = tif.rindex('.')
+        scaledtif = tif[:dotindex] + '_scaled' + tif[dotindex:]
+    [cols, rows] = raster.shape
+    driver = gdal.GetDriverByName("GTiff")
+    outds = driver.Create(scaledtif, rows, cols, 1, gdal_type)
+    outds.SetGeoTransform(geotiff.GetGeoTransform())
+    outds.SetProjection(geotiff.GetProjection())
+    outds.GetRasterBand(1).WriteArray(new_raster)
+    outds.GetRasterBand(1).SetMetadata(new_band_metadata)
+    outds.GetRasterBand(1).SetNoDataValue(nodata)
+    outds.SetMetadata(new_ds_metadata)
+    outds.FlushCache()
+    outds = None
+    band = None
+    geotiff = None
+    
+    return scaledtif  
+            

--- a/util_files.py
+++ b/util_files.py
@@ -1,0 +1,24 @@
+import os
+import dotenv
+dotenv.load_dotenv(os.getenv('RW_ENV'))
+
+def prep_dirs(dataset_name):
+    '''
+    Sets working directory for processing dataset, and creates needed directories as necessary
+    INPUT   dataset_name: full name of dataset to be processed
+    RETURN  data_dir: relative path of directory for holding downloaded and processed data
+    '''
+    # first, set the directory that you are working in with the path variable
+    path = os.path.join(os.getenv('PROCESSING_DIR'),dataset_name)
+    if not os.path.exists(path):
+        os.mkdir(path)
+    #move to this directory
+    os.chdir(path)
+
+    # create a new sub-directory within your specified dir called 'data'
+    # within this directory, create files to store raw and processed data
+    data_dir = 'data'
+    if not os.path.exists(data_dir):
+        os.mkdir(data_dir)
+    return data_dir
+

--- a/util_files.py
+++ b/util_files.py
@@ -1,6 +1,11 @@
 import os
+import sys
 import dotenv
 dotenv.load_dotenv(os.getenv('RW_ENV'))
+import subprocess
+import logging
+logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 def prep_dirs(dataset_name):
     '''
@@ -9,12 +14,13 @@ def prep_dirs(dataset_name):
     RETURN  data_dir: relative path of directory for holding downloaded and processed data
     '''
     # first, set the directory that you are working in with the path variable
-    path = os.path.join(os.getenv('PROCESSING_DIR'),dataset_name)
+    path = os.path.abspath(os.path.join(os.getenv('PROCESSING_DIR'),dataset_name))
     if not os.path.exists(path):
         os.mkdir(path)
     #move to this directory
     os.chdir(path)
-
+    logger.debug('Working directory absolute path: '+path)
+    
     # create a new sub-directory within your specified dir called 'data'
     # within this directory, create files to store raw and processed data
     data_dir = 'data'
@@ -22,3 +28,65 @@ def prep_dirs(dataset_name):
         os.mkdir(data_dir)
     return data_dir
 
+def convert_netcdf(nc, subdatasets):
+    '''
+    Convert netcdf files to geotifs
+    INPUT   nc: file name of netcdf to convert (string)
+            subdatasets: subdataset names to extract to individual geotiffs (list of strings)
+    RETURN  tifs: file names of generated geotiffs (list of strings)
+    '''
+    # create an empty list to store the names of the tifs we generate from this netcdf file
+    tifs = []
+    # go through each variables to process in this netcdf file
+    for sds in subdatasets:
+        # extract subdataset by name
+        # should be of the format 'NETCDF:"filename.nc":variable'
+        sds_path = f'NETCDF:"{nc}":{sds}'
+        # generate a name to save the tif file we will translate the netcdf file's subdataset into
+        sds_tif = '{}_{}.tif'.format(os.path.splitext(nc)[0], sds_path.split(':')[-1])
+        # translate the netcdf file's subdataset into a tif
+        cmd = ['gdal_translate','-q', '-a_srs', 'EPSG:4326', sds_path, sds_tif]
+        completed_process = subprocess.run(cmd, shell=False)
+        logger.debug(str(completed_process))
+        if completed_process.returncode!=0:
+            raise Exception('NetCDF conversion using gdal_translate failed! Command: '+str(cmd))
+        # add the new subdataset tif files to the list of tifs generated from this netcdf file
+        tifs.append(sds_tif)
+    return tifs
+
+def mask_geotiff(target, mask, maskedtif, nodata=-128):
+    '''
+    Apply mask geotiff to target, ie reassign all target pixels outside of mask to specific value.
+    Target pixels within mask remain unchanged.
+    INPUT   target: file name of (single-band) geotiff to be masked (string)
+            mask: file name of (single-band) mask geotiff, ie a binary raster (string)
+            maskedtif: file name of masked geotiff (string)
+            nodata: value to be written over existing target pixels outside of mask (int/float)
+    '''
+    calc_path = os.path.abspath(os.path.join(os.getenv('GDAL_DIR'),'gdal_calc.py'))
+    cmd = '{} "{}" -A {} -B {} --outfile={} --calc="((B==0)*{})+((B==1)*A)"'.format(sys.executable, calc_path, target, mask, maskedtif, nodata)
+#     cmd = '"{calc_path}" -A {target} -B {mask} --outfile={maskedtif} --calc="((B==0)*{nodata})+((B==1)*A)"'
+#     logger.debug('Mask GeoTiff command: '+cmd)
+    completed_process = subprocess.run(cmd, shell=False)
+    logger.debug(str(completed_process))
+    if completed_process.returncode!=0:
+        raise Exception('Masking of GeoTiff using gdal_calc.py failed! Command: '+str(cmd))
+#     instead using command line escape
+#     !gdal_calc.py -A {annual} -B {mask} --outfile={annual_masked} --calc="((B==0)*{nodata})+((B==1)*A)"
+    return    
+                  
+def merge_geotiffs(tifs, multitif):
+    '''
+    Merge input single-band geotiffs into one multi-band geotiff
+    INPUT   tifs: file names of all single-band geotiffs to merge (list of strings)
+            multitif: file name of resulting, multi-band geotiff
+    '''
+    # merge all the sub tifs from this netcdf to create an overall tif representing all variable
+    merge_path = os.path.abspath(os.path.join(os.getenv('GDAL_DIR'),'gdal_merge.py'))
+    cmd = '{} "{}" -separate {} -o {}'.format(sys.executable, merge_path, ' '.join(tifs), multitif)
+    completed_process = subprocess.run(cmd, shell=False)
+    logger.debug(str(completed_process))
+    if completed_process.returncode!=0:
+        raise Exception('Merging of GeoTiffs using gdal_merge.py failed! Command: '+str(cmd))
+    return    
+                  


### PR DESCRIPTION
Preprocessing for 3 ocean datasets are scripted in this branch:
- ocn.005 Historical Cyclone Intensity
- ocn.007 Coral Bleaching Monitoring
- ocn.009 Sea Surface Temperature Variability

Notes:
- ocn.007 is a NRT dataset. I have scripted the process for uploading the current (daily) data as a "normal" dataset; this can presumably form the basis of a comprehensive docker script.
- One or more scripts **require** a new environment variable that specifies the directory holding the GDAL executables and Python scripts (eg `gdal_merge.py`). I tried to avoid this, but running scripts with the `subprocess` module in Windows requires specifying the location of the non-executable files (like `.py` scripts), because Windows will only use the `PATH` environment variable to automatically resolve the location of executable files (`.exe`, `.bin`, etc). I could be wrong here but this seemed the simplest way to get it to work cross-platform. So in my case, my `.env` file includes the line `GDAL_DIR="C:/Program Files/GDAL"`
- I employed two helper files to contain common code: `util_files.py` for directory and file manipulation, including GDAL stuff, and `util_cloud.py` for GCS, GEE, and AWS interactions. This means that the dataset scripts are not strictly "standalone"; however, the preprocessing scripts automatically import the modules based on their location within the repo (no pip or conda installation involved), so someone who clones the repo should be able to immediately execute the preprocessing scripts without any extra steps. This makes the scripts much shorter and will make future maintenance much simpler in the event of changes to external modules, as has already happened with GEE.
- The scripts and helper modules are (mostly) using logging rather than printing directly to console (but the log is redirected to the normal output stream).