### PR TITLE
utils pathing corrected

### DIFF
--- a/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity_processing.py
+++ b/ocn_005_historical_cyclone_intensity/ocn_005_historical_cyclone_intensity_processing.py
@@ -5,8 +5,9 @@ import sys
 import dotenv
 dotenv.load_dotenv(os.path.abspath(os.getenv('RW_ENV')))
 
-if os.getenv('PROCESSING_DIR') not in sys.path:
-    sys.path.append(os.path.abspath(os.getenv('PROCESSING_DIR')))
+utils_path = os.path.join(os.path.abspath(os.getenv('PROCESSING_DIR')),'utils')
+if utils_path not in sys.path:
+    sys.path.append(utils_path)
 import util_files
 import util_cloud
 from zipfile import ZipFile

--- a/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring_processing.py
+++ b/ocn_007_coral_bleaching_monitoring/ocn_007_coral_bleaching_monitoring_processing.py
@@ -11,8 +11,9 @@ import os
 import sys
 import dotenv
 dotenv.load_dotenv(os.path.abspath(os.getenv('RW_ENV')))
-if os.getenv('PROCESSING_DIR') not in sys.path:
-    sys.path.append(os.path.abspath(os.getenv('PROCESSING_DIR')))
+utils_path = os.path.join(os.path.abspath(os.getenv('PROCESSING_DIR')),'utils')
+if utils_path not in sys.path:
+    sys.path.append(utils_path)
 import util_files
 import util_cloud
 import urllib

--- a/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability_processing.py
+++ b/ocn_009_sea_surface_temperature_variability/ocn_009_sea_surface_temperature_variability_processing.py
@@ -12,8 +12,9 @@ import os
 import sys
 import dotenv
 dotenv.load_dotenv(os.path.abspath(os.getenv('RW_ENV')))
-if os.getenv('PROCESSING_DIR') not in sys.path:
-    sys.path.append(os.path.abspath(os.getenv('PROCESSING_DIR')))
+utils_path = os.path.join(os.path.abspath(os.getenv('PROCESSING_DIR')),'utils')
+if utils_path not in sys.path:
+    sys.path.append(utils_path)
 import util_files
 import util_cloud
 import urllib


### PR DESCRIPTION
Simply adjusts the pathing for the imported `util_*` modules in order to reflect them getting moved into `/utils/`. Future processing script submissions will reflect this at submission, so won't need individual adjustment.